### PR TITLE
Update template to use parskip

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -20,6 +20,7 @@
 \usepackage{float} 
 \usepackage{pdfpages}
 \usepackage{chngcntr}
+\usepackage{parskip}
 %\counterwithin{figure}{section}
 %\renewcommand\thefigure{\thesection-\arabic{figure}}
 %\renewcommand\thefigure{\arabic{figure}}


### PR DESCRIPTION
According to the style guide there should be no identation on paragraphs (3.10).
Adding the package `parskip` to the template solves that in the most latextonian way.